### PR TITLE
Only print scope if one was defined

### DIFF
--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -18,15 +18,16 @@ const defaultCommitList string = `{{ range $index,$commit := .BreakingChanges -}
 {{ if eq $index 0 }}
 ## BREAKING CHANGES
 {{ end}}
-* **{{$.Backtick}}{{$commit.Scope}}{{$.Backtick}}** {{$commit.ParsedBreakingChangeMessage}}  
+* {{ if $commit.Scope }}**{{$.Backtick}}{{$commit.Scope}}{{$.Backtick}}**{{ end }} {{$commit.ParsedBreakingChangeMessage}}  
 introduced by commit: 
-{{$commit.ParsedMessage}} {{if $.HasURL}} ([{{ printf "%.7s" $commit.Commit.Hash}}]({{ replace $.URL "{{hash}}" $commit.Commit.Hash}}))  {{end}}
+{{$commit.ParsedMessage}} {{if $.HasURL}} ([{{ printf "%.7s" $commit.Commit.Hash}}]({{ replace $.URL "{{hash}}" $commit.Commit.Hash}})){{end}}
 {{ end -}}
 {{ range $key := .Order }}
-{{ $commits := index $.Commits $key}} {{if $commits -}}
+{{ $commits := index $.Commits $key -}}
+{{ if $commits }}
 ### {{ $key }}
-{{ range $index,$commit := $commits -}}
-* **{{$.Backtick}}{{$commit.Scope}}{{$.Backtick}}** {{$commit.ParsedMessage}} {{if $.HasURL}} ([{{ printf "%.7s" $commit.Commit.Hash}}]({{ replace $.URL "{{hash}}" $commit.Commit.Hash}}))  {{end}}
+{{ range $index,$commit := $commits }}
+* {{ if $commit.Scope}}**{{$.Backtick}}{{$commit.Scope}}{{$.Backtick}}** {{end}}{{$commit.ParsedMessage}}{{if $.HasURL}} ([{{ printf "%.7s" $commit.Commit.Hash}}]({{ replace $.URL "{{hash}}" $commit.Commit.Hash}})){{end}}
 {{ end -}}
 {{ end -}}
 {{ end -}}`

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -32,7 +32,7 @@ func TestChangelog(t *testing.T) {
 				"minor": []shared.AnalyzedCommit{
 					shared.AnalyzedCommit{
 						Commit: shared.Commit{
-							Message: "feat(test): my first commit",
+							Message: "feat(internal/changelog): my first commit",
 							Author:  "me",
 							Hash:    "12345667",
 						},
@@ -46,7 +46,30 @@ func TestChangelog(t *testing.T) {
 			},
 			result: &shared.GeneratedChangelog{
 				Title:   "v1.0.0 (2019-07-19)",
-				Content: "# v1.0.0 (2019-07-19)\n\n ### Features\n* **`internal/changelog`** my first commit  ([1234566](https://commit.url))  \n\n ",
+				Content: "# v1.0.0 (2019-07-19)\n\n\n### Features\n\n* **`internal/changelog`** my first commit ([1234566](https://commit.url))\n\n",
+			},
+			hasError: false,
+		},
+		{
+			testCase: "feat no scope",
+			analyzedCommits: map[shared.Release][]shared.AnalyzedCommit{
+				"minor": []shared.AnalyzedCommit{
+					shared.AnalyzedCommit{
+						Commit: shared.Commit{
+							Message: "feat: my first commit",
+							Author:  "me",
+							Hash:    "12345667",
+						},
+						ParsedMessage: "my first commit",
+						Tag:           "feat",
+						TagString:     "Features",
+						Print:         true,
+					},
+				},
+			},
+			result: &shared.GeneratedChangelog{
+				Title:   "v1.0.0 (2019-07-19)",
+				Content: "# v1.0.0 (2019-07-19)\n\n\n### Features\n\n* my first commit ([1234566](https://commit.url))\n\n",
 			},
 			hasError: false,
 		},
@@ -56,7 +79,7 @@ func TestChangelog(t *testing.T) {
 				"minor": []shared.AnalyzedCommit{
 					shared.AnalyzedCommit{
 						Commit: shared.Commit{
-							Message: "feat(test): my first commit",
+							Message: "feat(internal/changelog): my first commit",
 							Author:  "me",
 							Hash:    "12345667",
 						},
@@ -68,7 +91,7 @@ func TestChangelog(t *testing.T) {
 					},
 					shared.AnalyzedCommit{
 						Commit: shared.Commit{
-							Message: "feat(test): my first break: BREAKING CHANGE: change api to v2",
+							Message: "feat(internal/changelog): my first break: BREAKING CHANGE: change api to v2",
 							Author:  "me",
 							Hash:    "12345668",
 						},
@@ -83,7 +106,7 @@ func TestChangelog(t *testing.T) {
 			},
 			result: &shared.GeneratedChangelog{
 				Title:   "v1.0.0 (2019-07-19)",
-				Content: "# v1.0.0 (2019-07-19)\n\n## BREAKING CHANGES\n\n* **`internal/changelog`** change api to v2  \nintroduced by commit: \nmy first break  ([1234566](https://commit.url))  \n\n ### Features\n* **`internal/changelog`** my first commit  ([1234566](https://commit.url))  \n\n ",
+				Content: "# v1.0.0 (2019-07-19)\n\n## BREAKING CHANGES\n\n* **`internal/changelog`** change api to v2  \nintroduced by commit: \nmy first break  ([1234566](https://commit.url))\n\n\n### Features\n\n* **`internal/changelog`** my first commit ([1234566](https://commit.url))\n\n",
 			},
 			hasError: false,
 		},


### PR DESCRIPTION
The current change log package will print "**``**" if scope was not found on the commit message.  This removes the artifact from the generated markdown, as well as cleaning up some whitespace on the output.