### PR TITLE
fix(internal/assets): close zip writer before closing zip file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
-	google.golang.org/appengine v1.6.5
+	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.8

--- a/internal/assets/asset.go
+++ b/internal/assets/asset.go
@@ -149,7 +149,6 @@ func (a *Asset) ZipFile() (string, error) {
 	}
 
 	zipWriter := zip.NewWriter(zipFile)
-	defer zipWriter.Close()
 
 	fileToZipHeader, err := zip.FileInfoHeader(fileToZipInfo)
 	if err != nil {
@@ -166,9 +165,15 @@ func (a *Asset) ZipFile() (string, error) {
 	if _, err = io.Copy(fileToZipWriter, fileToZip); err != nil {
 		return "", errors.Wrap(err, "Could not zip file")
 	}
+
+	if err := zipWriter.Close(); err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("Could not close zipwriter for zip %s", a.path))
+	}
+
 	if err := zipFile.Close(); err != nil {
 		return "", errors.Wrap(err, "Could not close file")
 	}
 	a.zippedPath, err = filepath.Abs(zipFile.Name())
+
 	return a.zippedPath, err
 }


### PR DESCRIPTION
Zip files of release 1.4.1 are corrupt. Could not open any of them.