### PR TITLE
fix(internal/angular): fix angular parsing of breaking change messages that have multiple lines

### DIFF
--- a/internal/analyzer/angular.go
+++ b/internal/analyzer/angular.go
@@ -22,7 +22,7 @@ const ANGULAR = "angular"
 
 func newAngular() *angular {
 	return &angular{
-		regex: `^(TAG)(?:\((.*)\))?: (.*)`,
+		regex: `^(TAG)(?:\((.*)\))?: (?s)(.*)`,
 		log:   log.WithField("analyzer", ANGULAR),
 		rules: []Rule{
 			{
@@ -105,8 +105,8 @@ func (a *angular) analyze(commit shared.Commit, rule Rule) (shared.AnalyzedCommi
 			}
 			breakingChange := strings.SplitN(message, "BREAKING CHANGE:", 2)
 
-			analyzed.ParsedMessage = strings.Trim(breakingChange[0], " ")
-			analyzed.ParsedBreakingChangeMessage = strings.Trim(breakingChange[1], " ")
+			analyzed.ParsedMessage = strings.TrimSpace(breakingChange[0])
+			analyzed.ParsedBreakingChangeMessage = strings.TrimSpace(breakingChange[1])
 
 			a.log.Tracef(" %s, BREAKING CHANGE found", commit.Message)
 			return analyzed, true, nil

--- a/internal/analyzer/angular_test.go
+++ b/internal/analyzer/angular_test.go
@@ -93,6 +93,53 @@ func TestAngular(t *testing.T) {
 				},
 			},
 		},
+		{	testCase: "feat breaking change footer",
+			commits: []shared.Commit{
+				 shared.Commit{
+					Message: "feat(internal/changelog): my first commit",
+					Author:  "me",
+					Hash:    "12345667",
+				 },
+				 shared.Commit{
+				        Message: "feat(internal/changelog): my first break \n\nBREAKING CHANGE: change api to v2\n",
+					Author:  "me",
+					Hash:    "12345668",
+				 },
+			},
+			analyzedCommits: map[shared.Release][]shared.AnalyzedCommit{
+				 "minor": []shared.AnalyzedCommit{
+					shared.AnalyzedCommit{
+						Commit: shared.Commit{
+							Message: "feat(internal/changelog): my first commit",
+							Author:  "me",
+							Hash:    "12345667",
+						},
+						Scope:         "internal/changelog",
+						ParsedMessage: "my first commit",
+						Tag:           "feat",
+						TagString:     "Features",
+						Print:         true,
+					},
+				},
+				"major": []shared.AnalyzedCommit{
+					shared.AnalyzedCommit{
+						Commit: shared.Commit{
+							Message: "feat(internal/changelog): my first break \n\nBREAKING CHANGE: change api to v2\n",
+							Author:  "me",
+							Hash:    "12345668",
+						},
+						Scope:                       "internal/changelog",
+						ParsedMessage:               "my first break",
+						Tag:                         "feat",
+						TagString:                   "Features",
+						Print:                       true,
+						ParsedBreakingChangeMessage: "change api to v2",
+					},
+				},
+				"patch": []shared.AnalyzedCommit{},
+				"none":  []shared.AnalyzedCommit{},
+			},
+		},
 		{
 			testCase: "invalid",
 			analyzedCommits: map[shared.Release][]shared.AnalyzedCommit{


### PR DESCRIPTION
As per the angular commits conventions, when you have a "BREAKING CHANGE" it would go in the footer of the commit message, which wouldn't be part of the same single line. Since the regex being used was `.*` this caused a problem since by default, the `.` operator in golang regexp doesn't include newlines. So by adding the `(?s)` flag it'll make the `.` include newlines and pick up when there's a `BREAKING CHANGE:` message in the commit on a different line.

I also added a unit test for this case which caused a problem for us using `go-semantic-release`. Let me know if there's anything else you need from me in order to merge this :) Thanks much!