### PR TITLE
feat(release): add an option to skip the tag prefix 'v'

### DIFF
--- a/internal/releaser/git/git.go
+++ b/internal/releaser/git/git.go
@@ -67,7 +67,11 @@ func (g *Client) GetCompareURL(oldVersion, newVersion string) string {
 // CreateRelease creates release on remote
 func (g *Client) CreateRelease(releaseVersion *shared.ReleaseVersion, generatedChangelog *shared.GeneratedChangelog, _ *assets.Set) error {
 
-	tag := "v" + releaseVersion.Next.Version.String()
+	tagPrefix := "v"
+	if g.config.SkipTagPrefix {
+		tagPrefix = ""
+	}
+	tag := tagPrefix + releaseVersion.Next.Version.String()
 	g.log.Infof("create release with version %s", tag)
 
 	head, err := g.git.Repository.Head()

--- a/internal/releaser/github/github.go
+++ b/internal/releaser/github/github.go
@@ -89,8 +89,11 @@ func (g *Client) CreateRelease(releaseVersion *shared.ReleaseVersion, generatedC
 
 // CreateRelease creates release on remote
 func (g *Client) makeRelease(releaseVersion *shared.ReleaseVersion, generatedChangelog *shared.GeneratedChangelog) error {
-
-	tag := "v" + releaseVersion.Next.Version.String()
+	tagPrefix := "v"
+	if g.config.SkipTagPrefix {
+		tagPrefix = ""
+	}
+	tag := tagPrefix + releaseVersion.Next.Version.String()
 	g.log.Debugf("create release with version %s", tag)
 
 	prerelease := releaseVersion.Next.Version.Prerelease() != ""

--- a/internal/releaser/gitlab/gitlab.go
+++ b/internal/releaser/gitlab/gitlab.go
@@ -98,7 +98,11 @@ func (g *Client) CreateRelease(releaseVersion *shared.ReleaseVersion, generatedC
 // CreateRelease creates release on remote
 func (g *Client) makeRelease(releaseVersion *shared.ReleaseVersion, generatedChangelog *shared.GeneratedChangelog) error {
 
-	tag := "v" + releaseVersion.Next.Version.String()
+	tagPrefix := "v"
+	if g.config.SkipTagPrefix {
+		tagPrefix = ""
+	}
+	tag := tagPrefix + releaseVersion.Next.Version.String()
 	g.Release = tag
 	g.log.Infof("create release with version %s", tag)
 	url := fmt.Sprintf("%s/projects/%s/releases", g.apiURL, util.PathEscape(g.config.Repo))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ type GitHubProvider struct {
 	User        string `yaml:"user"`
 	CustomURL   string `yaml:"customUrl,omitempty"`
 	AccessToken string
+	SkipTagPrefix	bool `yaml:"skipTagPrefix"`
 }
 
 // GitLabProvider struct
@@ -51,6 +52,7 @@ type GitLabProvider struct {
 	Repo        string `yaml:"repo"`
 	CustomURL   string `yaml:"customUrl,omitempty"`
 	AccessToken string
+	SkipTagPrefix	bool `yaml:"skipTagPrefix"`
 }
 
 // GitProvider struct
@@ -59,6 +61,7 @@ type GitProvider struct {
 	Username string `yaml:"user"`
 	Auth     string `yaml:"auth"`
 	SSH      bool   `yaml:"ssh"`
+	SkipTagPrefix	bool `yaml:"skipTagPrefix"`
 }
 
 // Hooks struct


### PR DESCRIPTION
As mentioned in issue #47 this change is simple, but allows skipping the tag prefix. I have added a reverse flag (hence the skip in the name of the variable) to keep the backward compatibility. And since the only popular version prefix I have seen in use is 'v' it is ok to keep it fixed for now. 

