### PR TITLE
feat(release): add an option to specify a custom prefix for the version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Release Types
 
-| Type        |    Implemendet     |      Git tag       |     Changelog      |      Release       |  Write access git  |     Api token      |
+| Type        |    Implemented     |      Git tag       |     Changelog      |      Release       |  Write access git  |     Api token      |
 | ----------- | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
 | `github`    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 | `gitlab`    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
@@ -60,7 +60,7 @@ hooks:
 
 #### CommitFormat
 
-Set the commit format, at the moment we support ony [angular](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format), more coming soon.
+Set the commit format, at the moment we support only [angular](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format), more coming soon.
 
 ```yml
 commitFormat: angular
@@ -97,8 +97,10 @@ release: 'github'
 github:
   user: "<user/group"
   repo: "<repositroyname>"
-  ## Optional, if your not using github.com
+  ## Optional, if you are not using github.com
   customUrl: <https://your.github>
+  ## Optional, if you want to change the default tag prefix ("v")
+  tagPrefix: ""
 ```
 
 ##### Gitlab 
@@ -112,6 +114,8 @@ gitlab:
   repo: "<repositroyname>"  ## Example group/project
   ## Optional, if your not using gitlab.com
   customUrl: <https://your.gitlab>
+  ## Optional, if you want to change the default tag prefix ("v")
+  tagPrefix: ""
 ```
 
 ##### Git only 
@@ -125,6 +129,8 @@ git:
   email: "<email>" # Used for creating tag
   user: "<user>" : # Used for creating tag and pushing
   auth: "<token>" # Used for pushing, can be env "$GIT_TOKEN", will be replaced with env
+  ## Optional, if you want to change the default tag prefix ("v")
+  tagPrefix: ""
 ```
 
 
@@ -176,7 +182,7 @@ changelog:
 
 ### Version
 
-`go-semantic-release` has two modes for calcualting the version: automatic or manual.
+`go-semantic-release` has two modes for calculating the version: automatic or manual.
 
 #### Automatic
 

--- a/internal/releaser/git/git.go
+++ b/internal/releaser/git/git.go
@@ -67,7 +67,12 @@ func (g *Client) GetCompareURL(oldVersion, newVersion string) string {
 // CreateRelease creates release on remote
 func (g *Client) CreateRelease(releaseVersion *shared.ReleaseVersion, generatedChangelog *shared.GeneratedChangelog, _ *assets.Set) error {
 
-	tag := "v" + releaseVersion.Next.Version.String()
+	tagPrefix := config.DefaultTagPrefix
+	if g.config.TagPrefix != nil{
+		tagPrefix = *g.config.TagPrefix
+	}
+	tag := tagPrefix + releaseVersion.Next.Version.String()
+
 	g.log.Infof("create release with version %s", tag)
 
 	head, err := g.git.Repository.Head()

--- a/internal/releaser/github/github.go
+++ b/internal/releaser/github/github.go
@@ -90,7 +90,11 @@ func (g *Client) CreateRelease(releaseVersion *shared.ReleaseVersion, generatedC
 // CreateRelease creates release on remote
 func (g *Client) makeRelease(releaseVersion *shared.ReleaseVersion, generatedChangelog *shared.GeneratedChangelog) error {
 
-	tag := "v" + releaseVersion.Next.Version.String()
+	tagPrefix := config.DefaultTagPrefix
+	if g.config.TagPrefix != nil{
+		tagPrefix = *g.config.TagPrefix
+	}
+	tag := tagPrefix + releaseVersion.Next.Version.String()
 	g.log.Debugf("create release with version %s", tag)
 
 	prerelease := releaseVersion.Next.Version.Prerelease() != ""

--- a/internal/releaser/gitlab/gitlab.go
+++ b/internal/releaser/gitlab/gitlab.go
@@ -98,7 +98,11 @@ func (g *Client) CreateRelease(releaseVersion *shared.ReleaseVersion, generatedC
 // CreateRelease creates release on remote
 func (g *Client) makeRelease(releaseVersion *shared.ReleaseVersion, generatedChangelog *shared.GeneratedChangelog) error {
 
-	tag := "v" + releaseVersion.Next.Version.String()
+	tagPrefix := config.DefaultTagPrefix
+	if g.config.TagPrefix != nil{
+		tagPrefix = *g.config.TagPrefix
+	}
+	tag := tagPrefix + releaseVersion.Next.Version.String()
 	g.Release = tag
 	g.log.Infof("create release with version %s", tag)
 	url := fmt.Sprintf("%s/projects/%s/releases", g.apiURL, util.PathEscape(g.config.Repo))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	DefaultTagPrefix = "v"
+)
+
 // ChangelogConfig struct
 type ChangelogConfig struct {
 	PrintAll      bool            `yaml:"printAll,omitempty"`
@@ -44,6 +48,7 @@ type GitHubProvider struct {
 	User        string `yaml:"user"`
 	CustomURL   string `yaml:"customUrl,omitempty"`
 	AccessToken string
+	TagPrefix   *string `yaml:"tagPrefix,omitempty"`
 }
 
 // GitLabProvider struct
@@ -51,6 +56,7 @@ type GitLabProvider struct {
 	Repo        string `yaml:"repo"`
 	CustomURL   string `yaml:"customUrl,omitempty"`
 	AccessToken string
+	TagPrefix   *string `yaml:"tagPrefix,omitempty"`
 }
 
 // GitProvider struct
@@ -59,6 +65,7 @@ type GitProvider struct {
 	Username string `yaml:"user"`
 	Auth     string `yaml:"auth"`
 	SSH      bool   `yaml:"ssh"`
+	TagPrefix   *string `yaml:"tagPrefix,omitempty"`
 }
 
 // Hooks struct


### PR DESCRIPTION
Now, I have added a configuration that can be used to specify a custom prefix for the version tag. The default is "v" so it does not break things for the current users. 

This addresses #47 