### PR TITLE
fix(internal): improve git log for commits on current branch since last release

### DIFF
--- a/pkg/semanticrelease/semantic-release.go
+++ b/pkg/semanticrelease/semantic-release.go
@@ -131,7 +131,7 @@ func (s *SemanticRelease) GetNextVersion(provider *ci.ProviderConfig, force bool
 			Version: &newVersion,
 		},
 		Last: shared.ReleaseVersionEntry{
-			Commit:  lastVersionHash,
+			Commit:  lastVersionHash.Hash().String(),
 			Version: lastVersion,
 		},
 		Branch:  provider.Branch,
@@ -171,7 +171,7 @@ func (s *SemanticRelease) SetVersion(provider *ci.ProviderConfig, version string
 			Version: newVersion,
 		},
 		Last: shared.ReleaseVersionEntry{
-			Commit:  lastVersionHash,
+			Commit:  lastVersionHash.Hash().String(),
 			Version: lastVersion,
 		},
 		Branch: provider.Branch,


### PR DESCRIPTION
At the moment when PRs where done in parallel it could happen that some commits where ignored in the release. This should be fixed now